### PR TITLE
Oil & Gas page: add USA/Canada stocks, new metrics + Bitcoin 1yr chart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env and fill in your values.
+# Never commit .env to version control.
+
+# MongoDB Atlas connection string
+MONGO_URI=mongodb+srv://<user>:<password>@<cluster>.mongodb.net/?appName=<appName>
+
+# Alpha Vantage API key (free tier at https://www.alphavantage.co/support/#api-key)
+ALPHA_VANTAGE_KEY=your_alpha_vantage_key_here
+
+# EIA API key (optional, for oil price data — https://www.eia.gov/opendata/)
+EIA_API_KEY=your_eia_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ venv/
 # OS files
 .DS_Store
 Thumbs.db
+
+# One-off scripts
+fetch_bitcoin_history.py
+
+# Local secrets (use .env.example as template)
+*.env
+secrets.py

--- a/app/routes/coinbook.py
+++ b/app/routes/coinbook.py
@@ -2,7 +2,14 @@ from flask import Blueprint, render_template, jsonify, request
 import requests
 import datetime
 from app.services.coins import get_btc_data
-from app.services.mongo_price import save_price_history, get_price_history
+from app.services.mongo_price import (
+    save_price_history,
+    get_latest_price_date,
+    get_price_history,
+    save_crypto_metrics_history,
+    get_crypto_metrics_history,
+    get_latest_crypto_metrics_date,
+)
 
 coinbook = Blueprint("coinbook", __name__, url_prefix="/coinbook")
 
@@ -39,13 +46,25 @@ def bitcoin_history():
         '6m': 180,
         '1y': 365,
         '5y': 1825,
-        'all': 'max'
+        'all': 1825
     }
     days = range_map.get(range_param, 30)
+    if days == 'max' or days is None:
+        days = 1825
+    days = min(int(days), 1825)
 
-    history = get_price_history()
+    today = datetime.datetime.utcnow().date()
+    start_date = None
+    if isinstance(days, int):
+        start_date = today - datetime.timedelta(days=days)
 
-    if not history:
+    latest_db_date = get_latest_price_date('BTC')
+    history = get_price_history('BTC', start_date=start_date)
+
+    stale_cutoff = today - datetime.timedelta(days=1)
+    needs_api_fetch = not history or latest_db_date is None or latest_db_date < stale_cutoff
+
+    if needs_api_fetch:
         url = f'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days={days}'
         try:
             resp = requests.get(url, timeout=10)
@@ -53,14 +72,20 @@ def bitcoin_history():
                 return jsonify({'error': f'CoinGecko API returned {resp.status_code}'}), 500
             data = resp.json()
             raw_prices = data.get('prices', [])
-            save_price_history(raw_prices)
+            if raw_prices:
+                save_price_history('BTC', raw_prices)
+                save_crypto_metrics_history('bitcoin', data)
             labels = [datetime.datetime.fromtimestamp(p[0] / 1000).strftime('%Y-%m-%d %H:%M') for p in raw_prices]
             prices = [p[1] for p in raw_prices]
         except requests.exceptions.RequestException as e:
             return jsonify({'error': f'Failed to fetch data: {str(e)}'}), 500
     else:
-        labels = [datetime.datetime.fromtimestamp(h['timestamp'] / 1000).strftime('%Y-%m-%d %H:%M') for h in history]
-        prices = [h['price'] for h in history]
+        try:
+            labels = [h['date'].strftime('%Y-%m-%d %H:%M') if hasattr(h['date'], 'strftime') else str(h['date']) for h in history]
+            prices = [float(h['price']) for h in history]
+        except (KeyError, AttributeError, TypeError) as e:
+            print(f"[Bookopedia] Error formatting history: {e}")
+            return jsonify({'error': 'Failed to process price history'}), 500
 
     chart_data = {
         'labels': labels,
@@ -74,3 +99,53 @@ def bitcoin_history():
         ]
 
     return jsonify(chart_data)
+
+
+@coinbook.route('/api/bitcoin/metrics')
+def bitcoin_metrics():
+    range_param = request.args.get('range', '5y')
+
+    range_map = {
+        'daily': 1,
+        '7d': 7,
+        '30d': 30,
+        '6m': 180,
+        '1y': 365,
+        '5y': 1825,
+        'all': 1825
+    }
+    days = range_map.get(range_param, 1825)
+    if days == 'max' or days is None:
+        days = 1825
+    days = min(int(days), 1825)
+
+    today = datetime.datetime.utcnow().date()
+    start_date = today - datetime.timedelta(days=days)
+
+    latest_db_date = get_latest_crypto_metrics_date('bitcoin')
+    stale_cutoff = today - datetime.timedelta(days=1)
+    needs_api_fetch = latest_db_date is None or latest_db_date < stale_cutoff
+
+    if needs_api_fetch:
+        url = f'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days={days}'
+        try:
+            resp = requests.get(url, timeout=10)
+            if resp.status_code != 200:
+                return jsonify({'error': f'CoinGecko API returned {resp.status_code}'}), 500
+            data = resp.json()
+            save_crypto_metrics_history('bitcoin', data)
+        except requests.exceptions.RequestException as e:
+            return jsonify({'error': f'Failed to fetch data: {str(e)}'}), 500
+
+    rows = get_crypto_metrics_history('bitcoin', start_date=start_date)
+    labels = [r['date'].strftime('%Y-%m-%d') if hasattr(r['date'], 'strftime') else str(r['date']) for r in rows]
+    market_caps = [r.get('market_cap') for r in rows]
+    volumes = [r.get('volume') for r in rows]
+    supplies = [r.get('supply') for r in rows]
+
+    return jsonify({
+        'labels': labels,
+        'market_caps': market_caps,
+        'volumes': volumes,
+        'supplies': supplies,
+    })

--- a/app/routes/stocks.py
+++ b/app/routes/stocks.py
@@ -1,8 +1,67 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, jsonify, request
+
+from app.services.stocks_data import (
+    build_energy_chart,
+    build_oil_gas_table,
+    build_sector_snapshot,
+)
 
 stocks = Blueprint("stocks", __name__, url_prefix="/stocks")
 
 
 @stocks.route("/oil-gas")
 def oil_gas():
-    return render_template("stocks/oil_gas.html", active_page="oil_gas")
+    # USA majors + E&P + Oilfield Services; top 2 Canadian oil sands (NYSE-listed)
+    tickers = [
+        # USA Integrated
+        "XOM", "CVX", "COP", "OXY",
+        # USA E&P
+        "EOG", "DVN", "MRO",
+        # USA Refining
+        "VLO", "PSX",
+        # Oilfield Services
+        "SLB", "HAL",
+        # Canada
+        "SU", "CNQ",
+    ]
+    sector_map = {
+        "XOM": "Integrated",  "CVX": "Integrated",
+        "COP": "E&P",         "OXY": "E&P",
+        "EOG": "E&P",         "DVN": "E&P",         "MRO": "E&P",
+        "VLO": "Refining",    "PSX": "Refining",
+        "SLB": "Oilfield Svcs", "HAL": "Oilfield Svcs",
+        "SU":  "CA Integrated", "CNQ": "CA E&P",
+    }
+    country_map = {
+        "SU": "CA", "CNQ": "CA",
+    }
+
+    companies, errors, as_of = build_oil_gas_table(tickers, sector_map=sector_map, country_map=country_map)
+    sector_metric, sector_error = build_sector_snapshot(symbol="XLE")
+
+    # Only include sector metrics if we got data (no errors)
+    sector_metrics = [sector_metric] if sector_metric and not sector_error else []
+
+    return render_template(
+        "stocks/oil_gas.html",
+        active_page="oil_gas",
+        sector_metrics=sector_metrics,
+        companies=companies,
+        as_of=as_of,
+    )
+
+
+@stocks.route("/api/energy/history")
+def energy_history():
+    import traceback
+    try:
+        range_param = request.args.get("range", "30d")
+        chart_data, error = build_energy_chart(range_param=range_param, symbol="XLE")
+        if error:
+            print(f"[Bookopedia] Chart error: {error}")
+            return jsonify({"error": error}), 500
+        return jsonify(chart_data)
+    except Exception as e:
+        print(f"[Bookopedia] Unhandled exception in energy_history: {e}")
+        traceback.print_exc()
+        return jsonify({"error": str(e)}), 500

--- a/app/services/coins.py
+++ b/app/services/coins.py
@@ -1,8 +1,20 @@
 import requests
 import time
+import datetime
 
 
 def get_btc_data():
+    try:
+        from app.services.mongo_price import get_cached_crypto_metrics
+        cached = get_cached_crypto_metrics('bitcoin')
+        if cached:
+            updated_at = cached.get('updated_at')
+            if hasattr(updated_at, 'date'):
+                if updated_at.date() == datetime.date.today():
+                    return cached
+    except Exception as e:
+        print(f"[Bookopedia] Could not read cached metrics: {e}")
+
     url = "https://api.coingecko.com/api/v3/coins/markets"
     params = {
         "vs_currency": "usd",
@@ -43,10 +55,10 @@ def get_btc_data():
 
             # Cache to MongoDB on success
             try:
-                from app.services.mongo_price import save_btc_metrics
-                save_btc_metrics(btc_data)
+                from app.services.mongo_price import save_crypto_metrics
+                save_crypto_metrics('bitcoin', btc_data)
             except Exception as e:
-                print(f"[Coinbook] Could not cache metrics: {e}")
+                print(f"[Bookopedia] Could not cache metrics: {e}")
 
             return btc_data
 
@@ -58,13 +70,13 @@ def get_btc_data():
             time.sleep(1)
 
     # All retries failed — try MongoDB cache
-    print("[Coinbook] All API attempts failed. Trying cached data...")
+    print("[Bookopedia] All API attempts failed. Trying cached data...")
     try:
-        from app.services.mongo_price import get_cached_btc_metrics
-        cached = get_cached_btc_metrics()
+        from app.services.mongo_price import get_cached_crypto_metrics
+        cached = get_cached_crypto_metrics('bitcoin')
         if cached:
             return cached
     except Exception as e:
-        print(f"[Coinbook] Could not load cached metrics: {e}")
+        print(f"[Bookopedia] Could not load cached metrics: {e}")
 
     return None

--- a/app/services/mongo_price.py
+++ b/app/services/mongo_price.py
@@ -1,99 +1,339 @@
 import os
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
-from datetime import datetime
+from datetime import datetime, timedelta, date
+import time
 
-MONGO_URI = os.getenv('MONGO_URI', 'mongodb://localhost:27017/')
-DB_NAME = 'coinbook'
-PRICE_HISTORY_COLLECTION = 'btc_price_history'
-BTC_METRICS_COLLECTION = 'btc_metrics'
+MONGO_URI = os.getenv('MONGO_URI')  # Set via environment variable — see .env.example
+DB_NAME = 'bookopedia'
+PRICE_HISTORY_COLLECTION = 'daily_prices'
+BTC_METRICS_COLLECTION = 'crypto_metrics'
+CRYPTO_METRICS_HISTORY_COLLECTION = 'crypto_metrics_history'
+STOCK_SNAPSHOT_COLLECTION = 'stock_snapshots'
 
 try:
-    client = MongoClient(MONGO_URI, serverSelectionTimeoutMS=3000)
-    # Test connection
-    client.admin.command('ping')
+    if not MONGO_URI:
+        raise ValueError("MONGO_URI not set — running without MongoDB. Set env var to enable caching.")
+    client = MongoClient(MONGO_URI, serverSelectionTimeoutMS=2000, connectTimeoutMS=2000)
+    # Lazy connection - don't ping on startup
     db = client[DB_NAME]
     collection = db[PRICE_HISTORY_COLLECTION]
     metrics_collection = db[BTC_METRICS_COLLECTION]
-    MONGO_AVAILABLE = True
-    print("[Coinbook] MongoDB connected successfully.")
-except (ConnectionFailure, ServerSelectionTimeoutError, Exception) as e:
+    stock_snapshot_collection = db[STOCK_SNAPSHOT_COLLECTION]
+    crypto_metrics_history_collection = db[CRYPTO_METRICS_HISTORY_COLLECTION]
+    # Create indexes for efficient queries (this will attempt connection)
+    try:
+        collection.create_index('ticker')
+        collection.create_index('date')
+        collection.create_index([('ticker', 1), ('date', 1)])
+        crypto_metrics_history_collection.create_index('coin')
+        crypto_metrics_history_collection.create_index('date')
+        crypto_metrics_history_collection.create_index([('coin', 1), ('date', 1)])
+        MONGO_AVAILABLE = True
+        print("[Bookopedia] MongoDB Atlas connected successfully.")
+    except Exception as e:
+        MONGO_AVAILABLE = False
+        print(f"[Bookopedia] MongoDB indexes failed: {e}. Continuing without MongoDB.")
+except (ConnectionFailure, ServerSelectionTimeoutError, ValueError, Exception) as e:
     MONGO_AVAILABLE = False
     collection = None
     metrics_collection = None
-    print(f"[Coinbook] MongoDB not available ({e}). Using direct API mode.")
+    stock_snapshot_collection = None
+    crypto_metrics_history_collection = None
+    print(f"[Bookopedia] MongoDB not available ({e}). Using direct API mode.")
 
 
-def save_price_history(prices):
-    """Save prices to MongoDB. Silently skips if MongoDB is unavailable."""
+def save_price_history(ticker, prices):
+    """Save daily prices to MongoDB. Handles multiple formats:
+    - list of [timestamp_ms, price] pairs
+    - dict of {date_str: {ohlcv}} (Alpha Vantage format)
+    - list of dicts with 'date' and 'price' keys
+    
+    ticker: optional, defaults to 'BTC' for Bitcoin compatibility
+    """
+    # Handle being called with (prices) for Bitcoin - it's the old API
+    if isinstance(ticker, (list, dict)) and prices is None:
+        ticker = 'BTC'
+        prices = ticker
+        # Actually ticker was the first positional arg which was prices
+        prices = ticker
+    
+    # If ticket doesn't look like a real ticker, it's probably prices
+    if not isinstance(ticker, str) or len(ticker) > 10:
+        ticker_safe = 'BTC'
+        prices = ticker
+        ticker = ticker_safe
+    
     if not MONGO_AVAILABLE:
         return
     try:
-        docs = [
-            {
-                'timestamp': int(p[0]),
-                'date': datetime.fromtimestamp(p[0]/1000),
-                'price': p[1]
-            } for p in prices
-        ]
-        for doc in docs:
-            collection.update_one({'timestamp': doc['timestamp']}, {'$set': doc}, upsert=True)
+        docs = []
+        
+        if isinstance(prices, dict):
+            # Handle Alpha Vantage Time Series format: {"YYYY-MM-DD": {"4. close": "123.45", ...}}
+            for date_str, ohlcv in prices.items():
+                try:
+                    date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+                    close_price = float(ohlcv.get('4. close', ohlcv.get('close', 0)))
+                    docs.append({
+                        'ticker': ticker,
+                        'date': date_obj,
+                        'price': close_price
+                    })
+                except (ValueError, KeyError, TypeError):
+                    continue
+        else:
+            # Handle list format
+            for p in prices:
+                try:
+                    if isinstance(p, (list, tuple)) and len(p) >= 2:
+                        # Check if first element is timestamp (number) or date string
+                        if isinstance(p[0], (int, float)):
+                            date_obj = datetime.fromtimestamp(p[0] / 1000)
+                        elif isinstance(p[0], str):
+                            date_obj = datetime.strptime(p[0], '%Y-%m-%d')
+                        else:
+                            continue
+                        price = float(p[1])
+                    elif isinstance(p, dict):
+                        date_val = p.get('date')
+                        if isinstance(date_val, str):
+                            date_obj = datetime.strptime(date_val, '%Y-%m-%d')
+                        else:
+                            date_obj = date_val
+                        price = float(p.get('price', p.get('close', 0)))
+                    else:
+                        continue
+                    docs.append({
+                        'ticker': ticker,
+                        'date': date_obj,
+                        'price': price
+                    })
+                except (ValueError, TypeError, AttributeError):
+                    continue
+        
+        if docs:
+            for doc in docs:
+                collection.update_one(
+                    {'ticker': ticker, 'date': doc['date']},
+                    {'$set': doc},
+                    upsert=True
+                )
+            date_range = f"{min(d['date'] for d in docs)} to {max(d['date'] for d in docs)}"
+            print(f"[Bookopedia] Saved {len(docs)} daily prices for {ticker} to MongoDB ({date_range}).")
     except Exception as e:
-        print(f"[Coinbook] Failed to save to MongoDB: {e}")
+        print(f"[Bookopedia] Failed to save price history: {e}")
 
 
-def get_price_history(start_ts=None, end_ts=None):
-    """Get prices from MongoDB. Returns empty list if unavailable."""
+def get_price_history(ticker='BTC', start_date=None, end_date=None):
+    """Get daily prices from MongoDB. Defaults to BTC for Bitcoin compatibility."""
     if not MONGO_AVAILABLE:
         return []
     try:
-        query = {}
-        if start_ts:
-            query['timestamp'] = {'$gte': start_ts}
-        if end_ts:
-            query['timestamp'] = query.get('timestamp', {})
-            query['timestamp']['$lte'] = end_ts
-        return list(collection.find(query).sort('timestamp', 1))
+        query = {'ticker': ticker}
+        if start_date:
+            # Convert date to datetime if needed for MongoDB
+            if isinstance(start_date, date) and not isinstance(start_date, datetime):
+                start_dt = datetime.combine(start_date, datetime.min.time())
+            else:
+                start_dt = start_date
+            query['date'] = {'$gte': start_dt}
+        if end_date:
+            # Convert date to datetime if needed for MongoDB
+            if isinstance(end_date, date) and not isinstance(end_date, datetime):
+                end_dt = datetime.combine(end_date, datetime.max.time())
+            else:
+                end_dt = end_date
+            query['date'] = query.get('date', {})
+            query['date']['$lte'] = end_dt
+        results = list(collection.find(query).sort('date', 1))
+        return results
     except Exception as e:
-        print(f"[Coinbook] Failed to read from MongoDB: {e}")
+        print(f"[Bookopedia] Failed to read price history: {e}")
         return []
+
+
+def get_latest_price_date(ticker):
+    """Get the most recent date we have price data for a ticker."""
+    if not MONGO_AVAILABLE:
+        return None
+    try:
+        result = collection.find_one({'ticker': ticker}, sort=[('date', -1)])
+        if result:
+            date_val = result['date']
+            # Extract date part if it's a datetime
+            if isinstance(date_val, datetime):
+                return date_val.date()
+            elif isinstance(date_val, date):
+                return date_val
+            return date_val
+        return None
+    except Exception as e:
+        print(f"[Bookopedia] Failed to get latest date for {ticker}: {e}")
+        return None
 
 
 # ---- BTC Metrics Cache ----
 
-def save_btc_metrics(data):
-    """Save BTC metrics snapshot to MongoDB for caching."""
+def save_crypto_metrics(coin, data):
+    """Save crypto metrics snapshot to MongoDB for caching."""
     if not MONGO_AVAILABLE or not data:
         return
     try:
         doc = {
-            'coin': 'bitcoin',
+            'coin': coin,
             'updated_at': datetime.utcnow(),
             **data
         }
         metrics_collection.update_one(
-            {'coin': 'bitcoin'},
+            {'coin': coin},
             {'$set': doc},
             upsert=True
         )
-        print("[Coinbook] BTC metrics cached to MongoDB.")
+        print(f"[Bookopedia] {coin} metrics cached to MongoDB.")
     except Exception as e:
-        print(f"[Coinbook] Failed to cache BTC metrics: {e}")
+        print(f"[Bookopedia] Failed to cache {coin} metrics: {e}")
 
 
-def get_cached_btc_metrics():
-    """Get cached BTC metrics from MongoDB. Returns None if unavailable."""
+def get_cached_crypto_metrics(coin):
+    """Get cached crypto metrics from MongoDB. Returns None if unavailable."""
     if not MONGO_AVAILABLE:
         return None
     try:
-        doc = metrics_collection.find_one({'coin': 'bitcoin'})
+        doc = metrics_collection.find_one({'coin': coin})
         if doc:
-            # Remove MongoDB internal fields
             doc.pop('_id', None)
             doc.pop('coin', None)
-            print(f"[Coinbook] Serving cached BTC metrics (last updated: {doc.get('updated_at', 'unknown')})")
+            print(f"[Bookopedia] Serving cached {coin} metrics (updated: {doc.get('updated_at', 'unknown')})")
             return doc
         return None
     except Exception as e:
-        print(f"[Coinbook] Failed to read cached BTC metrics: {e}")
+        print(f"[Bookopedia] Failed to read cached {coin} metrics: {e}")
+        return None
+
+
+def save_crypto_metrics_history(coin, market_chart_payload):
+    """Save crypto metrics history (price, market cap, volume, supply) to MongoDB."""
+    if not MONGO_AVAILABLE or not market_chart_payload:
+        return
+    try:
+        prices = market_chart_payload.get('prices') or []
+        market_caps = market_chart_payload.get('market_caps') or []
+        volumes = market_chart_payload.get('total_volumes') or []
+
+        if not prices:
+            return
+
+        points = min(len(prices), len(market_caps), len(volumes))
+        docs = {}
+
+        for i in range(points):
+            try:
+                ts = prices[i][0]
+                price = float(prices[i][1])
+                market_cap = float(market_caps[i][1]) if market_caps[i] else None
+                volume = float(volumes[i][1]) if volumes[i] else None
+                supply = (market_cap / price) if market_cap and price else None
+
+                date_obj = datetime.fromtimestamp(ts / 1000)
+                date_key = date_obj.replace(hour=0, minute=0, second=0, microsecond=0)
+
+                docs[date_key] = {
+                    'coin': coin,
+                    'date': date_key,
+                    'price': price,
+                    'market_cap': market_cap,
+                    'volume': volume,
+                    'supply': supply,
+                }
+            except (TypeError, ValueError, IndexError):
+                continue
+
+        for doc in docs.values():
+            crypto_metrics_history_collection.update_one(
+                {'coin': coin, 'date': doc['date']},
+                {'$set': doc},
+                upsert=True
+            )
+
+        print(f"[Bookopedia] Saved {len(docs)} crypto metrics rows for {coin}.")
+    except Exception as e:
+        print(f"[Bookopedia] Failed to save {coin} metrics history: {e}")
+
+
+def get_crypto_metrics_history(coin, start_date=None, end_date=None):
+    """Get crypto metrics history from MongoDB."""
+    if not MONGO_AVAILABLE:
+        return []
+    try:
+        query = {'coin': coin}
+        if start_date:
+            if isinstance(start_date, date) and not isinstance(start_date, datetime):
+                start_dt = datetime.combine(start_date, datetime.min.time())
+            else:
+                start_dt = start_date
+            query['date'] = {'$gte': start_dt}
+        if end_date:
+            if isinstance(end_date, date) and not isinstance(end_date, datetime):
+                end_dt = datetime.combine(end_date, datetime.max.time())
+            else:
+                end_dt = end_date
+            query['date'] = query.get('date', {})
+            query['date']['$lte'] = end_dt
+        return list(crypto_metrics_history_collection.find(query).sort('date', 1))
+    except Exception as e:
+        print(f"[Bookopedia] Failed to read {coin} metrics history: {e}")
+        return []
+
+
+def get_latest_crypto_metrics_date(coin):
+    """Get the most recent metrics date for a coin."""
+    if not MONGO_AVAILABLE:
+        return None
+    try:
+        result = crypto_metrics_history_collection.find_one({'coin': coin}, sort=[('date', -1)])
+        if result:
+            date_val = result['date']
+            if isinstance(date_val, datetime):
+                return date_val.date()
+            if isinstance(date_val, date):
+                return date_val
+            return date_val
+        return None
+    except Exception as e:
+        print(f"[Bookopedia] Failed to get latest metrics date for {coin}: {e}")
+        return None
+
+
+def save_stock_snapshot(ticker, snapshot_data):
+    """Save one company snapshot to MongoDB."""
+    if not MONGO_AVAILABLE or not snapshot_data:
+        return
+    try:
+        doc = {
+            'ticker': ticker,
+            'updated_at': datetime.utcnow(),
+            **snapshot_data
+        }
+        stock_snapshot_collection.update_one(
+            {'ticker': ticker},
+            {'$set': doc},
+            upsert=True
+        )
+    except Exception as e:
+        print(f"[Bookopedia] Failed to save stock snapshot for {ticker}: {e}")
+
+
+def get_cached_stock_snapshot(ticker):
+    """Get cached stock snapshot from MongoDB."""
+    if not MONGO_AVAILABLE:
+        return None
+    try:
+        doc = stock_snapshot_collection.find_one({'ticker': ticker})
+        if doc:
+            doc.pop('_id', None)
+            return doc
+        return None
+    except Exception as e:
+        print(f"[Bookopedia] Failed to read stock snapshot for {ticker}: {e}")
         return None

--- a/app/services/stocks_data.py
+++ b/app/services/stocks_data.py
@@ -1,0 +1,398 @@
+import os
+import time
+import requests
+from datetime import datetime, timedelta
+
+ALPHA_VANTAGE_BASE = "https://www.alphavantage.co/query"
+
+_CACHE = {}
+
+
+def _get_cached(key, ttl_seconds):
+    cached = _CACHE.get(key)
+    if not cached:
+        return None
+    if time.time() - cached["ts"] > ttl_seconds:
+        return None
+    return cached["data"]
+
+
+def _set_cache(key, data):
+    _CACHE[key] = {"ts": time.time(), "data": data}
+
+
+def _alpha_vantage_get(params, cache_key, ttl_seconds=900):
+    cached = _get_cached(cache_key, ttl_seconds)
+    if cached is not None:
+        return cached
+
+    api_key = os.getenv("ALPHA_VANTAGE_KEY")
+    if not api_key:
+        return {"error": "Missing ALPHA_VANTAGE_KEY"}
+
+    params = {**params, "apikey": api_key}
+    try:
+        resp = requests.get(ALPHA_VANTAGE_BASE, params=params, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        return {"error": f"Alpha Vantage request failed: {exc}"}
+
+    if "Note" in data:
+        return {"error": data.get("Note")}
+    if "Information" in data:
+        return {"error": data.get("Information")}
+
+    _set_cache(cache_key, data)
+    return data
+
+
+def _to_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_int(value):
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_market_cap(value):
+    if value is None:
+        return "N/A"
+    if value >= 1_000_000_000_000:
+        return f"{value / 1_000_000_000_000:.2f}T"
+    if value >= 1_000_000_000:
+        return f"{value / 1_000_000_000:.2f}B"
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.2f}M"
+    return str(value)
+
+
+def get_company_overview(symbol):
+    return _alpha_vantage_get(
+        {"function": "OVERVIEW", "symbol": symbol},
+        cache_key=f"overview:{symbol}",
+        ttl_seconds=21600,
+    )
+
+
+def get_global_quote(symbol):
+    return _alpha_vantage_get(
+        {"function": "GLOBAL_QUOTE", "symbol": symbol},
+        cache_key=f"quote:{symbol}",
+        ttl_seconds=900,
+    )
+
+
+def get_cash_flow(symbol):
+    return _alpha_vantage_get(
+        {"function": "CASH_FLOW", "symbol": symbol},
+        cache_key=f"cashflow:{symbol}",
+        ttl_seconds=21600,
+    )
+
+
+def get_daily_series(symbol):
+    return _alpha_vantage_get(
+        {"function": "TIME_SERIES_DAILY", "symbol": symbol, "outputsize": "compact"},
+        cache_key=f"daily:{symbol}",
+        ttl_seconds=21600,
+    )
+
+
+def _compute_fcf_ratio(market_cap, cash_flow_payload):
+    if market_cap is None or not cash_flow_payload or "annualReports" not in cash_flow_payload:
+        return None
+
+    reports = cash_flow_payload.get("annualReports") or []
+    if not reports:
+        return None
+
+    latest = reports[0]
+    operating_cashflow = _to_float(latest.get("operatingCashflow"))
+    capital_expenditures = _to_float(latest.get("capitalExpenditures"))
+
+    if operating_cashflow is None or capital_expenditures is None:
+        return None
+
+    if capital_expenditures > 0:
+        capital_expenditures = -capital_expenditures
+
+    free_cash_flow = operating_cashflow + capital_expenditures
+    if free_cash_flow <= 0:
+        return None
+
+    return market_cap / free_cash_flow
+
+
+def build_company_snapshot(symbol, sector_override=None):
+    """Fetch company data with smart MongoDB caching. Only API calls if snapshot is stale."""
+    from app.services.mongo_price import get_cached_stock_snapshot, save_stock_snapshot
+    
+    # Check if we have a fresh cached snapshot (same day)
+    cached = get_cached_stock_snapshot(symbol)
+    if cached:
+        updated_at = cached.get('updated_at')
+        if isinstance(updated_at, str):
+            updated_at = datetime.fromisoformat(updated_at)
+        if updated_at and updated_at.date() == datetime.now().date():
+            print(f"[Bookopedia] Using cached snapshot for {symbol}")
+            return cached, None
+    
+    # Cache is stale or missing — fetch from API
+    print(f"[Bookopedia] Fetching fresh data for {symbol} from Alpha Vantage...")
+    overview = get_company_overview(symbol)
+    if "error" in overview:
+        if cached:
+            print(f"[Bookopedia] API failed for {symbol}, using stale cache")
+            return cached, overview["error"]
+        # No cache at all — return a skeleton row so the company still shows
+        return {
+            "name": symbol, "ticker": symbol,
+            "sector": sector_override or "Energy", "country": "USA",
+            "price": None, "market_cap": "N/A", "pe": None,
+            "forward_pe": None, "price_to_book": None, "price_to_fcf": None,
+            "ev_to_ebitda": None, "dividend_yield": None, "roe": None,
+            "low_52": None, "high_52": None, "range_percent": None,
+            "latest_trading_day": None, "_pending": True,
+        }, overview["error"]
+
+    quote = get_global_quote(symbol)
+    if "error" in quote:
+        if cached:
+            return cached, quote["error"]
+        return {
+            "name": overview.get("Name") or symbol, "ticker": symbol,
+            "sector": sector_override or overview.get("Sector") or "Energy",
+            "country": overview.get("Country") or "USA",
+            "price": None, "market_cap": _format_market_cap(_to_int(overview.get("MarketCapitalization"))),
+            "pe": _to_float(overview.get("PERatio")),
+            "forward_pe": _to_float(overview.get("ForwardPE")),
+            "price_to_book": _to_float(overview.get("PriceToBookRatio")),
+            "price_to_fcf": None,
+            "ev_to_ebitda": _to_float(overview.get("EVToEBITDA")),
+            "dividend_yield": _to_float(overview.get("DividendYield")),
+            "roe": _to_float(overview.get("ReturnOnEquityTTM")),
+            "low_52": _to_float(overview.get("52WeekLow")),
+            "high_52": _to_float(overview.get("52WeekHigh")),
+            "range_percent": None, "latest_trading_day": None, "_pending": True,
+        }, quote["error"]
+
+    # Fetch cash flow — non-blocking: if it fails, P/FCF just shows as N/A
+    cashflow = get_cash_flow(symbol)
+    cashflow_error = cashflow.get("error") if cashflow else None
+    if cashflow_error:
+        print(f"[Bookopedia] Cash flow unavailable for {symbol} ({cashflow_error}), P/FCF will be N/A")
+
+    quote_data = quote.get("Global Quote", {})
+
+    price = _to_float(quote_data.get("05. price"))
+    latest_trading_day = quote_data.get("07. latest trading day")
+
+    market_cap = _to_int(overview.get("MarketCapitalization"))
+    pe_ratio = _to_float(overview.get("PERatio"))
+    price_to_book = _to_float(overview.get("PriceToBookRatio"))
+    low_52 = _to_float(overview.get("52WeekLow"))
+    high_52 = _to_float(overview.get("52WeekHigh"))
+
+    range_percent = None
+    if price is not None and low_52 is not None and high_52 is not None and high_52 > low_52:
+        range_percent = max(0.0, min(100.0, (price - low_52) / (high_52 - low_52) * 100))
+
+    price_to_fcf = None if cashflow_error else _compute_fcf_ratio(market_cap, cashflow)
+
+    dividend_yield = _to_float(overview.get("DividendYield"))
+    ev_to_ebitda   = _to_float(overview.get("EVToEBITDA"))
+    roe            = _to_float(overview.get("ReturnOnEquityTTM"))
+    forward_pe     = _to_float(overview.get("ForwardPE"))
+
+    snapshot = {
+        "name": overview.get("Name") or symbol,
+        "ticker": symbol,
+        "sector": sector_override or overview.get("Sector") or "Energy",
+        "country": overview.get("Country") or "USA",
+        "price": price,
+        "market_cap": _format_market_cap(market_cap),
+        "pe": pe_ratio,
+        "forward_pe": forward_pe,
+        "price_to_book": price_to_book,
+        "price_to_fcf": price_to_fcf,
+        "ev_to_ebitda": ev_to_ebitda,
+        "dividend_yield": dividend_yield,
+        "roe": roe,
+        "low_52": low_52,
+        "high_52": high_52,
+        "range_percent": range_percent,
+        "latest_trading_day": latest_trading_day,
+    }
+    
+    # Save to MongoDB
+    save_stock_snapshot(symbol, snapshot)
+    
+    return snapshot, None
+
+
+def build_energy_chart(range_param="30d", symbol="XLE"):
+    """Fetch XLE chart data: first check MongoDB, only fetch API if missing today's data.
+    If last date in MongoDB is older than today, fetches ALL missing dates from API.
+    """
+    from app.services.mongo_price import get_price_history, get_latest_price_date, save_price_history
+    
+    range_map = {
+        "7d": 7,
+        "30d": 30,
+        "3m": 90,
+        "6m": 180,
+        "1y": 365,
+        "5y": 1825,
+    }
+    days = range_map.get(range_param, 30)
+    start_date = datetime.now().date() - timedelta(days=days)
+    today = datetime.now().date()
+
+    # Check if we have data up to the most recent market day in MongoDB
+    latest_db_date = get_latest_price_date(symbol)
+    stale_cutoff = today - timedelta(days=3)
+    needs_api_fetch = latest_db_date is None or latest_db_date < stale_cutoff
+    
+    if needs_api_fetch:
+        if latest_db_date:
+            print(f"[Bookopedia] Last price for {symbol} in MongoDB is {latest_db_date}. Today is {today}. Fetching from API...")
+        else:
+            print(f"[Bookopedia] No price data for {symbol} in MongoDB. Fetching from API...")
+        
+        try:
+            series = get_daily_series(symbol)
+            if "error" in series:
+                # Try to use stale MongoDB data if API fails
+                db_prices = get_price_history(symbol, start_date=start_date)
+                if db_prices:
+                    print(f"[Bookopedia] API failed for {symbol}, using stale cached data.")
+                    labels = [p['date'].strftime('%Y-%m-%d') if hasattr(p['date'], 'strftime') else str(p['date']) for p in db_prices]
+                    prices = [p['price'] for p in db_prices]
+                    return {"labels": labels, "prices": prices}, None
+                return None, series["error"]
+            
+            time_series = series.get("Time Series (Daily)") or {}
+            if time_series:
+                # This saves ALL dates returned by API (typically last 100 days)
+                # So it fills in all gaps from last_db_date to today
+                save_price_history(symbol, time_series)
+                print(f"[Bookopedia] Backfilled {len(time_series)} trading days for {symbol}.")
+        except Exception as e:
+            print(f"[Bookopedia] Error fetching/saving {symbol} data: {e}")
+            # Try to use stale MongoDB data if API fails
+            db_prices = get_price_history(symbol, start_date=start_date)
+            if db_prices:
+                print(f"[Bookopedia] Using stale cached data after error.")
+                labels = [p['date'].strftime('%Y-%m-%d') if hasattr(p['date'], 'strftime') else str(p['date']) for p in db_prices]
+                prices = [p['price'] for p in db_prices]
+                return {"labels": labels, "prices": prices}, None
+            return None, f"Error fetching data: {str(e)}"
+    
+    # Always load from MongoDB (fresh if just updated, cached if not)
+    db_prices = get_price_history(symbol, start_date=start_date)
+    if not db_prices:
+        return None, "No price data available"
+    
+    labels = []
+    prices = []
+    for p in db_prices:
+        date_obj = p['date']
+        # Handle both datetime and date objects
+        if isinstance(date_obj, datetime):
+            labels.append(date_obj.strftime('%Y-%m-%d'))
+        else:
+            labels.append(str(date_obj))
+        prices.append(p['price'])
+    
+    return {"labels": labels, "prices": prices}, None
+
+
+def build_sector_snapshot(symbol="XLE"):
+    """Build sector snapshot with smart MongoDB caching."""
+    from app.services.mongo_price import get_latest_price_date, get_price_history, save_price_history
+    
+    today = datetime.now().date()
+    latest_db_date = get_latest_price_date(symbol)
+    stale_cutoff = today - timedelta(days=3)
+    needs_api_fetch = latest_db_date is None or latest_db_date < stale_cutoff
+    
+    if needs_api_fetch:
+        print(f"[Bookopedia] Fetching sector snapshot data for {symbol}...")
+        series = get_daily_series(symbol)
+        if "error" not in series:
+            time_series = series.get("Time Series (Daily)") or {}
+            if time_series:
+                save_price_history(symbol, time_series)
+    
+    # Get latest 2 days from MongoDB
+    db_prices = get_price_history(symbol)
+    if not db_prices or len(db_prices) < 2:
+        return None, "Not enough data for sector snapshot"
+    
+    latest = db_prices[-1]
+    prev = db_prices[-2]
+    
+    latest_close = latest.get('price')
+    prev_close = prev.get('price')
+    
+    if latest_close is None or prev_close is None:
+        return None, "Missing close prices"
+    
+    change_pct = ((latest_close - prev_close) / prev_close) * 100
+    
+    as_of = latest.get('date')
+    if hasattr(as_of, 'strftime'):
+        as_of = as_of.strftime('%Y-%m-%d')
+
+    return {
+        "label": f"Energy Sector ({symbol})",
+        "value": f"${latest_close:,.2f}",
+        "subtext": "Close",
+        "trend_class": "green" if change_pct >= 0 else "red",
+        "trend_text": f"{change_pct:+.2f}% 1d",
+        "as_of": as_of,
+    }, None
+
+
+def build_oil_gas_table(tickers, sector_map=None, country_map=None):
+    sector_map  = sector_map  or {}
+    country_map = country_map or {}
+    results = []
+    errors = []
+    as_of = None
+
+    # All keys the template expects — ensures old cached docs don't crash Jinja
+    DEFAULTS = {
+        "name": None, "ticker": None, "sector": "Energy", "country": "USA",
+        "price": None, "market_cap": "N/A", "pe": None, "forward_pe": None,
+        "price_to_book": None, "price_to_fcf": None, "ev_to_ebitda": None,
+        "dividend_yield": None, "roe": None,
+        "low_52": None, "high_52": None, "range_percent": None,
+        "latest_trading_day": None, "_pending": False,
+    }
+
+    for symbol in tickers:
+        snapshot, err = build_company_snapshot(symbol, sector_override=sector_map.get(symbol))
+        if err:
+            errors.append(f"{symbol}: {err}")
+        if snapshot is None:
+            row = {**DEFAULTS, "name": symbol, "ticker": symbol,
+                   "sector": sector_map.get(symbol, "Energy"),
+                   "country": country_map.get(symbol, "USA"), "_pending": True}
+        else:
+            # Merge with defaults so any missing key from old cache is filled in
+            row = {**DEFAULTS, **snapshot}
+            if symbol in country_map:
+                row["country"] = country_map[symbol]
+        results.append(row)
+        if not as_of and row.get("latest_trading_day"):
+            as_of = row["latest_trading_day"]
+
+    return results, errors, as_of

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -350,6 +350,159 @@ body {
     height: 100% !important;
 }
 
+#energyChart {
+    width: 100% !important;
+    height: 100% !important;
+}
+
+/* ---- Tables ---- */
+.table-wrap {
+    border: 1px solid #e8dcc8;
+    border-radius: 12px;
+    overflow-x: auto;
+    background: #fff;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    min-width: 720px;
+}
+
+.data-table th,
+.data-table td {
+    padding: 0.75rem 0.7rem;
+    text-align: left;
+    border-bottom: 1px solid #f1e6d2;
+}
+
+.data-table th {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #7a5c2e;
+    background: #fbf6ea;
+}
+
+.data-table tbody tr:hover {
+    background: #fff6e6;
+}
+
+.range-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.7rem;
+    color: #8a7a60;
+    margin-bottom: 0.25rem;
+}
+
+.range-bar {
+    height: 8px;
+    background: #f1e6d2;
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid #e1d2b6;
+}
+
+.range-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #d7952f 0%, #b86b1c 100%);
+}
+
+.ticker-tag {
+    display: inline-block;
+    font-weight: 700;
+    font-size: 0.75rem;
+    letter-spacing: 0.5px;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    color: #3b2f1e;
+    background: #f1e6d2;
+    border: 1px solid #e1d2b6;
+}
+
+.pill {
+    display: inline-block;
+    font-size: 0.7rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: #fff3df;
+    color: #7a5c2e;
+    border: 1px solid #e8dcc8;
+}
+
+.muted-note {
+    margin-top: 0.6rem;
+    font-size: 0.8rem;
+    color: #8a7a60;
+    font-style: italic;
+}
+
+/* ---- ETF Grid ---- */
+.etf-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+@media (min-width: 700px) {
+    .etf-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.etf-card {
+    background: #fdfaf2;
+    border: 1px solid #e8dcc8;
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+.etf-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.6rem;
+}
+
+.etf-card h4 {
+    font-family: 'Merriweather', Georgia, serif;
+    font-size: 1rem;
+    color: #3b2f1e;
+    margin-bottom: 0.4rem;
+}
+
+.etf-card p {
+    font-size: 0.85rem;
+    color: #5c4a2a;
+    margin-bottom: 0.6rem;
+}
+
+.etf-meta {
+    font-size: 0.75rem;
+    color: #8a7a60;
+}
+
+/* ---- Themes ---- */
+.theme-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.theme-list li {
+    padding: 0.5rem 0.8rem;
+    border: 1px solid #e8dcc8;
+    border-radius: 10px;
+    background: #fdfaf2;
+    margin-bottom: 0.6rem;
+    font-size: 0.9rem;
+    color: #3b2f1e;
+}
+
 /* ---- Description Section ---- */
 .description-section { margin-top: 2rem; padding-top: 1rem; }
 

--- a/app/templates/coinbook/bitcoin.html
+++ b/app/templates/coinbook/bitcoin.html
@@ -62,7 +62,6 @@
                     <option value="6m">6m</option>
                     <option value="1y">1y</option>
                     <option value="5y">5y</option>
-                    <option value="all">All</option>
                 </select>
                 <label for="chartType">Chart Type:</label>
                 <select id="chartType">
@@ -72,6 +71,23 @@
             </div>
             <div class="chart-container">
                 <canvas id="btcChart"></canvas>
+            </div>
+        </section>
+
+        <!-- Volume/Price Correlation Chart -->
+        <section class="chart-section">
+            <h3 class="section-header">&#128202; Volume & Price Correlation</h3>
+            <div class="chart-controls">
+                <label for="correlationRange">Time Range:</label>
+                <select id="correlationRange">
+                    <option value="30d">30d</option>
+                    <option value="6m">6m</option>
+                    <option value="1y" selected>1y</option>
+                    <option value="5y">5y</option>
+                </select>
+            </div>
+            <div class="chart-container">
+                <canvas id="correlationChart"></canvas>
             </div>
         </section>
 
@@ -103,7 +119,10 @@
 
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
 <script>
+let priceStats = { min: null, max: null, change: null, changePct: null };
+
 function fetchAndRenderChart(range, type) {
     fetch(`/coinbook/api/bitcoin/history?range=${range}&type=${type}`)
         .then(res => res.json())
@@ -117,57 +136,139 @@ function fetchAndRenderChart(range, type) {
 
             if (type === 'line') {
                 const labels = data.labels.map(l => l.split(' ')[0]);
+                const prices = data.prices;
+                
+                // Calculate stats
+                const minPrice = Math.min(...prices);
+                const maxPrice = Math.max(...prices);
+                const firstPrice = prices[0];
+                const lastPrice = prices[prices.length - 1];
+                const priceChange = lastPrice - firstPrice;
+                const priceChangePct = ((priceChange / firstPrice) * 100).toFixed(2);
+                
+                priceStats = { min: minPrice, max: maxPrice, change: priceChange, changePct: priceChangePct };
+
                 window.btcChartInstance = new Chart(ctx, {
                     type: 'line',
                     data: {
                         labels: labels,
                         datasets: [{
                             label: 'BTC Price (USD)',
-                            data: data.prices,
-                            borderColor: '#f7931a',
-                            backgroundColor: 'rgba(247,147,26,0.08)',
-                            borderWidth: 2,
+                            data: prices,
+                            borderColor: priceChange >= 0 ? '#26a69a' : '#ef5350',
+                            backgroundColor: priceChange >= 0 ? 'rgba(38,166,154,0.08)' : 'rgba(239,83,80,0.08)',
+                            borderWidth: 2.5,
                             pointRadius: 0,
-                            pointHoverRadius: 5,
+                            pointHoverRadius: 6,
+                            pointHoverBackgroundColor: '#fff',
+                            pointHoverBorderWidth: 2,
                             fill: true,
-                            tension: 0.3
+                            tension: 0.4,
+                            segment: {
+                                borderColor: ctx => {
+                                    const curr = ctx.p1.parsed.y;
+                                    const prev = ctx.p0.parsed.y;
+                                    return curr >= prev ? 'rgba(38,166,154,0.9)' : 'rgba(239,83,80,0.9)';
+                                }
+                            }
                         }]
                     },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
+                        animation: {
+                            duration: 750,
+                            easing: 'easeInOutQuart'
+                        },
                         plugins: {
                             legend: { display: false },
                             tooltip: {
+                                enabled: true,
+                                mode: 'index',
+                                intersect: false,
+                                backgroundColor: 'rgba(0,0,0,0.85)',
+                                titleColor: '#fff',
+                                bodyColor: '#fff',
+                                borderColor: priceChange >= 0 ? '#26a69a' : '#ef5350',
+                                borderWidth: 2,
+                                padding: 12,
+                                displayColors: false,
                                 callbacks: {
                                     title: items => items[0].label,
-                                    label: ctx => '$' + ctx.parsed.y.toLocaleString(undefined, {minimumFractionDigits: 2})
+                                    label: ctx => {
+                                        const price = ctx.parsed.y;
+                                        const idx = ctx.dataIndex;
+                                        const change = idx > 0 ? price - prices[idx - 1] : 0;
+                                        const changePct = idx > 0 ? ((change / prices[idx - 1]) * 100).toFixed(2) : 0;
+                                        return [
+                                            `Price: $${price.toLocaleString(undefined, {minimumFractionDigits: 2})}`,
+                                            idx > 0 ? `Change: ${change >= 0 ? '+' : ''}$${change.toFixed(2)} (${changePct >= 0 ? '+' : ''}${changePct}%)` : ''
+                                        ].filter(Boolean);
+                                    },
+                                    footer: () => {
+                                        return `Min: $${minPrice.toLocaleString()} | Max: $${maxPrice.toLocaleString()}`;
+                                    }
+                                }
+                            },
+                            zoom: {
+                                pan: {
+                                    enabled: true,
+                                    mode: 'x',
+                                    modifierKey: 'ctrl',
+                                },
+                                zoom: {
+                                    wheel: {
+                                        enabled: true,
+                                        speed: 0.1
+                                    },
+                                    pinch: {
+                                        enabled: true
+                                    },
+                                    mode: 'x',
                                 }
                             }
                         },
                         scales: {
                             x: {
-                                grid: { display: false },
+                                grid: { 
+                                    display: true,
+                                    color: 'rgba(0,0,0,0.04)',
+                                    lineWidth: 1
+                                },
                                 ticks: {
-                                    maxTicksLimit: 8,
+                                    maxTicksLimit: 12,
                                     autoSkip: true,
                                     maxRotation: 0,
-                                    font: { size: 11 }
+                                    font: { size: 11, weight: '500' },
+                                    color: '#666'
                                 }
                             },
                             y: {
-                                grid: { color: 'rgba(0,0,0,0.05)' },
+                                type: 'linear',
+                                position: 'right',
+                                grid: { 
+                                    color: 'rgba(0,0,0,0.06)',
+                                    lineWidth: 1
+                                },
                                 ticks: {
-                                    callback: v => '$' + v.toLocaleString(),
-                                    font: { size: 11 }
-                                }
+                                    callback: v => '$' + v.toLocaleString(undefined, {maximumFractionDigits: 0}),
+                                    font: { size: 11, weight: '500' },
+                                    color: '#666',
+                                    padding: 8
+                                },
+                                beginAtZero: false
                             }
+                        },
+                        interaction: {
+                            mode: 'index',
+                            intersect: false,
                         }
                     }
                 });
             } else if (type === 'candlestick' && data.candles) {
                 const labels = data.candles.map(c => c.t.split(' ')[0]);
                 const closes = data.candles.map(c => c.c);
+                
                 window.btcChartInstance = new Chart(ctx, {
                     type: 'bar',
                     data: {
@@ -176,18 +277,74 @@ function fetchAndRenderChart(range, type) {
                             label: 'BTC Close Price (USD)',
                             data: closes,
                             backgroundColor: closes.map((c, i) =>
-                                i > 0 && c >= closes[i-1] ? 'rgba(38,166,154,0.7)' : 'rgba(239,83,80,0.7)'
+                                i > 0 && c >= closes[i-1] ? 'rgba(38,166,154,0.85)' : 'rgba(239,83,80,0.85)'
                             ),
-                            borderRadius: 2
+                            borderColor: closes.map((c, i) =>
+                                i > 0 && c >= closes[i-1] ? 'rgba(38,166,154,1)' : 'rgba(239,83,80,1)'
+                            ),
+                            borderWidth: 1,
+                            borderRadius: 0,
+                            barThickness: 'flex',
+                            maxBarThickness: 8
                         }]
                     },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
-                        plugins: { legend: { display: false } },
+                        animation: {
+                            duration: 500,
+                            easing: 'easeInOutQuart'
+                        },
+                        plugins: { 
+                            legend: { display: false },
+                            tooltip: {
+                                backgroundColor: 'rgba(0,0,0,0.85)',
+                                padding: 12,
+                                displayColors: false,
+                                callbacks: {
+                                    title: items => items[0].label,
+                                    label: ctx => `Close: $${ctx.parsed.y.toLocaleString(undefined, {minimumFractionDigits: 2})}`
+                                }
+                            },
+                            zoom: {
+                                pan: {
+                                    enabled: true,
+                                    mode: 'x',
+                                    modifierKey: 'ctrl',
+                                },
+                                zoom: {
+                                    wheel: {
+                                        enabled: true,
+                                        speed: 0.1
+                                    },
+                                    pinch: {
+                                        enabled: true
+                                    },
+                                    mode: 'x',
+                                }
+                            }
+                        },
                         scales: {
-                            x: { grid: { display: false }, ticks: { maxTicksLimit: 10, font: { size: 11 } } },
-                            y: { ticks: { callback: v => '$' + v.toLocaleString(), font: { size: 11 } } }
+                            x: { 
+                                grid: { display: false },
+                                ticks: { 
+                                    maxTicksLimit: 12, 
+                                    font: { size: 11 },
+                                    color: '#666'
+                                } 
+                            },
+                            y: { 
+                                type: 'linear',
+                                position: 'right',
+                                grid: { color: 'rgba(0,0,0,0.06)' },
+                                ticks: { 
+                                    callback: v => '$' + v.toLocaleString(),
+                                    font: { size: 11 },
+                                    color: '#666',
+                                    padding: 8
+                                },
+                                beginAtZero: false
+                            }
                         }
                     }
                 });
@@ -196,14 +353,209 @@ function fetchAndRenderChart(range, type) {
         .catch(err => console.error('Chart fetch error:', err));
 }
 
+function fetchAndRenderCorrelation(range) {
+    fetch(`/coinbook/api/bitcoin/metrics?range=${range}`)
+        .then(res => res.json())
+        .then(data => {
+            if (data.error) {
+                console.error('Metrics API error:', data.error);
+                return;
+            }
+            
+            const ctx = document.getElementById('correlationChart').getContext('2d');
+            if (window.correlationChartInstance) window.correlationChartInstance.destroy();
+
+            // Get price data from history endpoint for correlation
+            return fetch(`/coinbook/api/bitcoin/history?range=${range}`)
+                .then(res => res.json())
+                .then(priceData => {
+                    const labels = data.labels;
+                    const volumes = data.volumes.map(v => v / 1e9); // Convert to billions
+                    const prices = priceData.prices;
+
+                    // Calculate dynamic ranges
+                    const minPrice = Math.min(...prices.filter(p => p));
+                    const maxPrice = Math.max(...prices.filter(p => p));
+                    const minVolume = Math.min(...volumes.filter(v => v));
+                    const maxVolume = Math.max(...volumes.filter(v => v));
+
+                    window.correlationChartInstance = new Chart(ctx, {
+                        type: 'line',
+                        data: {
+                            labels: labels,
+                            datasets: [
+                                {
+                                    label: 'Price (USD)',
+                                    data: prices,
+                                    borderColor: '#f7931a',
+                                    backgroundColor: 'rgba(247,147,26,0.12)',
+                                    borderWidth: 2.5,
+                                    pointRadius: 0,
+                                    pointHoverRadius: 5,
+                                    pointHoverBackgroundColor: '#fff',
+                                    pointHoverBorderWidth: 2,
+                                    yAxisID: 'y-price',
+                                    fill: true,
+                                    tension: 0.4,
+                                    order: 2
+                                },
+                                {
+                                    label: 'Volume (B USD)',
+                                    data: volumes,
+                                    type: 'bar',
+                                    backgroundColor: 'rgba(100,149,237,0.6)',
+                                    borderColor: 'rgba(100,149,237,0.9)',
+                                    borderWidth: 0,
+                                    yAxisID: 'y-volume',
+                                    order: 1,
+                                    barThickness: 'flex',
+                                    maxBarThickness: 6
+                                }
+                            ]
+                        },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            animation: {
+                                duration: 750,
+                                easing: 'easeInOutQuart'
+                            },
+                            interaction: {
+                                mode: 'index',
+                                intersect: false,
+                            },
+                            plugins: {
+                                legend: {
+                                    display: true,
+                                    position: 'top',
+                                    align: 'end',
+                                    labels: { 
+                                        font: { size: 11, weight: '600' },
+                                        boxWidth: 14,
+                                        boxHeight: 14,
+                                        padding: 15,
+                                        usePointStyle: true,
+                                        pointStyle: 'circle'
+                                    }
+                                },
+                                tooltip: {
+                                    backgroundColor: 'rgba(0,0,0,0.85)',
+                                    titleColor: '#fff',
+                                    bodyColor: '#fff',
+                                    borderColor: '#f7931a',
+                                    borderWidth: 2,
+                                    padding: 12,
+                                    displayColors: true,
+                                    callbacks: {
+                                        title: items => items[0].label,
+                                        label: function(context) {
+                                            let label = context.dataset.label || '';
+                                            if (label) label += ': ';
+                                            if (context.parsed.y !== null) {
+                                                if (context.dataset.yAxisID === 'y-price') {
+                                                    label += '$' + context.parsed.y.toLocaleString(undefined, {minimumFractionDigits: 2});
+                                                } else {
+                                                    label += '$' + context.parsed.y.toFixed(2) + 'B';
+                                                }
+                                            }
+                                            return label;
+                                        }
+                                    }
+                                },
+                                zoom: {
+                                    pan: {
+                                        enabled: true,
+                                        mode: 'x',
+                                        modifierKey: 'ctrl',
+                                    },
+                                    zoom: {
+                                        wheel: {
+                                            enabled: true,
+                                            speed: 0.1
+                                        },
+                                        pinch: {
+                                            enabled: true
+                                        },
+                                        mode: 'x',
+                                    }
+                                }
+                            },
+                            scales: {
+                                x: {
+                                    grid: { 
+                                        display: true,
+                                        color: 'rgba(0,0,0,0.04)'
+                                    },
+                                    ticks: {
+                                        maxTicksLimit: 12,
+                                        autoSkip: true,
+                                        maxRotation: 0,
+                                        font: { size: 10, weight: '500' },
+                                        color: '#666'
+                                    }
+                                },
+                                'y-price': {
+                                    type: 'linear',
+                                    position: 'left',
+                                    grid: { color: 'rgba(247,147,26,0.08)' },
+                                    min: minPrice * 0.95,
+                                    max: maxPrice * 1.05,
+                                    ticks: {
+                                        callback: v => '$' + v.toLocaleString(undefined, {maximumFractionDigits: 0}),
+                                        font: { size: 10, weight: '500' },
+                                        color: '#f7931a',
+                                        padding: 8
+                                    },
+                                    title: {
+                                        display: true,
+                                        text: 'Price (USD)',
+                                        color: '#f7931a',
+                                        font: { size: 12, weight: 'bold' },
+                                        padding: { bottom: 10 }
+                                    }
+                                },
+                                'y-volume': {
+                                    type: 'linear',
+                                    position: 'right',
+                                    grid: { display: false },
+                                    min: 0,
+                                    max: maxVolume * 1.5,
+                                    ticks: {
+                                        callback: v => '$' + v.toFixed(1) + 'B',
+                                        font: { size: 10, weight: '500' },
+                                        color: '#6495ed',
+                                        padding: 8
+                                    },
+                                    title: {
+                                        display: true,
+                                        text: 'Volume (USD)',
+                                        color: '#6495ed',
+                                        font: { size: 12, weight: 'bold' },
+                                        padding: { bottom: 10 }
+                                    }
+                                }
+                            }
+                        }
+                    });
+                });
+        })
+        .catch(err => console.error('Correlation chart error:', err));
+}
+
 window.addEventListener('DOMContentLoaded', function() {
     fetchAndRenderChart('30d', 'line');
+    fetchAndRenderCorrelation('1y');
+    
     document.getElementById('chartRange').addEventListener('change', function() {
         fetchAndRenderChart(this.value, document.getElementById('chartType').value);
     });
     document.getElementById('chartType').addEventListener('change', function() {
         fetchAndRenderChart(document.getElementById('chartRange').value, this.value);
     });
+    document.getElementById('correlationRange').addEventListener('change', function() {
+        fetchAndRenderCorrelation(this.value);
+    });
 });
+
 </script>
 {% endblock %}

--- a/app/templates/stocks/oil_gas.html
+++ b/app/templates/stocks/oil_gas.html
@@ -13,25 +13,134 @@
         <h2 class="chapter-title">Oil &amp; Gas Industry Analysis</h2>
 
         <div class="book-description">
-            <span class="drop-cap">T</span>his section will track key metrics and trends in the Oil &amp; Gas industry, including stock performance of major companies, crude oil prices, production volumes, and sector-wide analysis using freely available market data.
+            <span class="drop-cap">T</span>his chapter tracks oil and gas market conditions alongside the largest listed companies. It highlights crude pricing, sector performance, and company-level valuation signals so readers can connect the commodity cycle with equities.
         </div>
 
         <div class="book-description">
-            Analysis will cover companies like ExxonMobil, Chevron, Shell, BP, and ConocoPhillips, as well as ETFs tracking the energy sector. Historical price data, P/E ratios, dividend yields, and correlation with commodity prices will be visualized.
+            The figures below refresh from free public APIs. Due to rate limits, some rows may show N/A during peak usage.
         </div>
 
-        <section class="coming-soon">
-            <div class="coming-soon-box">
-                <h3>&#128679; Coming Soon</h3>
-                <p>We're collecting and organizing Oil &amp; Gas stock data. This chapter will include:</p>
-                <ul>
-                    <li>Major O&amp;G stock price charts</li>
-                    <li>Crude oil price correlation</li>
-                    <li>Sector ETF performance</li>
-                    <li>Dividend yield tracking</li>
-                    <li>Historical P/E ratios</li>
-                </ul>
+        {% if sector_metrics %}
+        <section class="metrics-grid">
+            {% for metric in sector_metrics %}
+            <div class="metric-card">
+                <div class="metric-label">{{ metric.label }}</div>
+                <div class="metric-value">{{ metric.value }}</div>
+                <div class="metric-subtext">{{ metric.subtext }}</div>
+                <div class="metric-subtext {{ metric.trend_class }}">{{ metric.trend_text }}</div>
             </div>
+            {% endfor %}
+        </section>
+        {% else %}
+        <p class="error-msg">&#9888;&#65039; Sector snapshot is unavailable right now.</p>
+        {% endif %}
+
+        <section class="chart-section">
+            <h3 class="section-header">&#128200; Energy Sector (XLE) Price History</h3>
+            <div class="chart-controls">
+                <label for="energyRange">Time Range:</label>
+                <select id="energyRange">
+                    <option value="7d">7d</option>
+                    <option value="30d" selected>30d</option>
+                    <option value="3m">3m</option>
+                    <option value="6m">6m</option>
+                    <option value="1y">1y</option>
+                    <option value="5y">5y</option>
+                </select>
+            </div>
+            <div class="chart-container">
+                <canvas id="energyChart"></canvas>
+            </div>
+        </section>
+
+        <section class="chart-section">
+            <h3 class="section-header">&#128200; Major Oil &amp; Gas Stocks — USA &amp; Canada</h3>
+
+            <div class="metrics-key" style="margin-bottom:1rem;font-size:0.82rem;color:#666;line-height:1.6;">
+                <strong>Key Metrics Guide:</strong>
+                <span style="margin-left:0.8rem;"><em>P/E</em> = Price / Earnings &mdash; lower is cheaper relative to profits.</span>
+                <span style="margin-left:0.8rem;"><em>P/FCF</em> = Price / Free Cash Flow &mdash; critical for capital-intensive oil firms; &lt;15 is attractive.</span>
+                <span style="margin-left:0.8rem;"><em>EV/EBITDA</em> = Enterprise Value / EBITDA &mdash; sector standard; oil majors typically 5–10×.</span>
+                <span style="margin-left:0.8rem;"><em>Div. Yield</em> = Annual dividend as % of price &mdash; oil majors often 3–6%.</span>
+                <span style="margin-left:0.8rem;"><em>ROE</em> = Return on Equity &mdash; measures how efficiently capital is deployed.</span>
+            </div>
+
+            {% if companies %}
+            <div class="table-wrap">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Country</th>
+                            <th>Sector</th>
+                            <th>Company</th>
+                            <th>Price</th>
+                            <th>Mkt Cap</th>
+                            <th>52W Range</th>
+                            <th>Div. Yield</th>
+                            <th>P/E</th>
+                            <th>EV/EBITDA</th>
+                            <th>P/FCF</th>
+                            <th>P/B</th>
+                            <th>ROE</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for company in companies %}
+                        {% set country = company.country | upper if company.country else "USA" %}
+                        <tr>
+                            <td>
+                                <span class="country-badge country-{{ 'ca' if country == 'CA' or country == 'CANADA' else 'us' }}">
+                                    {{ "🇨🇦" if country == "CA" or country == "CANADA" else "🇺🇸" }}
+                                </span>
+                            </td>
+                            <td><span class="sector-tag">{{ company.sector }}</span></td>
+                            <td>
+                                <span class="ticker-tag">{{ company.ticker }}</span>
+                                <span class="company-name-sm">{{ company.name }}</span>
+                            </td>
+                            <td class="num-cell">{{ "$" + "{:,.2f}".format(company.price) if company.price is not none else "N/A" }}</td>
+                            <td class="num-cell">{{ company.market_cap }}</td>
+                            <td>
+                                {% if company.low_52 is not none and company.high_52 is not none %}
+                                <div class="range-labels">
+                                    <span>${{ "{:.0f}".format(company.low_52) }}</span>
+                                    <span>${{ "{:.0f}".format(company.high_52) }}</span>
+                                </div>
+                                <div class="range-bar">
+                                    <div class="range-fill" style="width: {{ "{:.0f}".format(company.range_percent or 0) }}%"></div>
+                                </div>
+                                {% else %}N/A{% endif %}
+                            </td>
+                            <td class="num-cell {% if company.dividend_yield is not none and company.dividend_yield >= 0.03 %}val-good{% endif %}">
+                                {{ "{:.1f}%".format(company.dividend_yield * 100) if company.dividend_yield is not none else "—" }}
+                            </td>
+                            <td class="num-cell {% if company.pe is not none and company.pe < 12 %}val-good{% elif company.pe is not none and company.pe > 25 %}val-warn{% endif %}">
+                                {{ "{:.1f}x".format(company.pe) if company.pe is not none else "—" }}
+                            </td>
+                            <td class="num-cell {% if company.ev_to_ebitda is not none and company.ev_to_ebitda < 8 %}val-good{% elif company.ev_to_ebitda is not none and company.ev_to_ebitda > 14 %}val-warn{% endif %}">
+                                {{ "{:.1f}x".format(company.ev_to_ebitda) if company.ev_to_ebitda is not none else "—" }}
+                            </td>
+                            <td class="num-cell {% if company.price_to_fcf is not none and company.price_to_fcf < 15 %}val-good{% elif company.price_to_fcf is not none and company.price_to_fcf > 25 %}val-warn{% endif %}">
+                                {{ "{:.1f}x".format(company.price_to_fcf) if company.price_to_fcf is not none else "—" }}
+                            </td>
+                            <td class="num-cell">{{ "{:.2f}x".format(company.price_to_book) if company.price_to_book is not none else "—" }}</td>
+                            <td class="num-cell {% if company.roe is not none and company.roe >= 0.15 %}val-good{% elif company.roe is not none and company.roe < 0.05 %}val-warn{% endif %}">
+                                {{ "{:.1f}%".format(company.roe * 100) if company.roe is not none else "—" }}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <div class="muted-note" style="margin-top:0.5rem;">
+                Snapshot as of {{ as_of or "latest trading day" }}.
+                <span style="margin-left:1rem;color:#26a69a;">&#9679; Green</span> = attractive.
+                <span style="margin-left:0.5rem;color:#ef5350;">&#9679; Warm</span> = stretched valuation.
+                Rate limits may leave some cells empty on first load.
+            </div>
+            {% else %}
+            <p class="error-msg">&#9888;&#65039; Company data is not available.</p>
+            {% endif %}
         </section>
 
         <div class="page-footer">
@@ -40,4 +149,87 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<style>
+/* Oil & Gas table enhancements */
+.num-cell { text-align: right; font-variant-numeric: tabular-nums; }
+.val-good  { color: #26a69a; font-weight: 600; }
+.val-warn  { color: #ef5350; font-weight: 600; }
+
+.country-badge { font-size: 1.1rem; }
+.company-name-sm { display: block; font-size: 0.72rem; color: #888; margin-top: 1px; max-width: 140px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.sector-tag { background: rgba(184,107,28,0.12); color: #7a4a10; border-radius: 4px; padding: 1px 6px; font-size: 0.73rem; white-space: nowrap; }
+
+.metrics-key em { background: #f5f0e8; border-radius: 3px; padding: 0 3px; }
+.data-table th, .data-table td { padding: 6px 10px; }
+.data-table thead th { background: #f5f0e8; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.03em; }
+.data-table tbody tr:hover { background: rgba(184,107,28,0.04); }
+.table-wrap { overflow-x: auto; }
+</style>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+function fetchEnergyChart(range) {
+    fetch(`/stocks/api/energy/history?range=${range}`)
+        .then(res => res.json())
+        .then(data => {
+            if (data.error) {
+                console.error('API error:', data.error);
+                return;
+            }
+            const ctx = document.getElementById('energyChart').getContext('2d');
+            if (window.energyChartInstance) window.energyChartInstance.destroy();
+
+            window.energyChartInstance = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: data.labels,
+                    datasets: [{
+                        label: 'XLE Close (USD)',
+                        data: data.prices,
+                        borderColor: '#b86b1c',
+                        backgroundColor: 'rgba(184,107,28,0.12)',
+                        borderWidth: 2,
+                        pointRadius: 0,
+                        pointHoverRadius: 4,
+                        fill: true,
+                        tension: 0.3
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: ctx => '$' + ctx.parsed.y.toLocaleString(undefined, {minimumFractionDigits: 2})
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            grid: { display: false },
+                            ticks: { maxTicksLimit: 8, autoSkip: true, maxRotation: 0, font: { size: 11 } }
+                        },
+                        y: {
+                            grid: { color: 'rgba(0,0,0,0.05)' },
+                            ticks: { callback: v => '$' + v.toLocaleString(), font: { size: 11 } }
+                        }
+                    }
+                }
+            });
+        })
+        .catch(err => console.error('Chart fetch error:', err));
+}
+
+window.addEventListener('DOMContentLoaded', function() {
+    const rangeSelect = document.getElementById('energyRange');
+    fetchEnergyChart(rangeSelect.value);
+    rangeSelect.addEventListener('change', function() {
+        fetchEnergyChart(this.value);
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
- Oil & Gas page: expanded to 13 tickers (XOM, CVX, COP, OXY, EOG, DVN, MRO, VLO, PSX, SLB, HAL + CA: SU, CNQ)
- Added Dividend Yield, EV/EBITDA, ROE columns with colour-coded valuation signals
- Cashflow now non-blocking so rate-limit errors don't drop entire row
- Snapshot schema normalised: old cached docs always get missing keys filled in
- Bitcoin chart: capped to 1-year (CoinGecko free tier limit); defaults to 1y range
- MongoDB: MONGO_URI read from env var only (no hardcoded credentials)
- Added .env.example; updated .gitignore to exclude .env and debug scripts